### PR TITLE
Add Readiness and Healthiness Routes

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,6 +7,9 @@ on your system and check again if it is already fixed/implemented. Thank you for
 ## The description of the bug or the rationle of your proposal
 <!-- replace me -->
 
+## A snippet of code for replicating the issue or showing the proposal usage if applicable
+<!-- replace me -->
+
 ## The expected result for your bug
 <!-- replace me -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
 of the work you have done and be sure to link to the relative open issue if is present.
 
-Be aaware that all the work you have done should include also the relative tests to assure the
+Be aware that all the work you have done should include also the relative tests to assure the
 correct behaviour and avoid possible regressions in the future.
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changes to `lc39`
+
+### TBR
+
+### v0.1.0 (2019-01-08)
+- Initial relase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes to `lc39`
 
 ### TBR
+- Add `/-/healthz and` `/-/ready` status endpoints.
 
 ### v0.1.0 (2019-01-08)
 - Initial relase

--- a/docs/main-entrypoint.md
+++ b/docs/main-entrypoint.md
@@ -39,15 +39,15 @@ For doing so you can add two new `module.exports` to your main entrypoint that w
 module.exports.readinessHandler = function readinessHandler(request, reply) {
   // Add your custom logic for /-/ready here
 }
-module.exports.healthinessHandler = function readinessHandler(request, reply) {
+module.exports.healthinessHandler = function healthinessHandler(request, reply) {
   // Add your custom logic for /-/healthz here
 }
 ```
 
 Both of these entpoint will be validated agains a JSON schema that you can find [here][status-routes-schema].  
-Additionally you will be able to access the variable `this.serviceName` to use it as the value of the `name`
-property in the response and it will default to the name of your service as set by `npm` or the one in
-`package.json`.
+Additionally you will be able to access the variables `this.serviceName` and `this.serviceVersion`
+to use them as the value for the `name` and `version` properties in the response and
+they will default to the name and version of your service as set by `npm` or the ones in `package.json`.
 
 **BE AWARE**  
 Both of this endpoints are set to permanently run on log level `silent` for decreasing the amount of noise in the logs during the

--- a/docs/main-entrypoint.md
+++ b/docs/main-entrypoint.md
@@ -15,5 +15,44 @@ module.exports = async function service(fastify) {
   })
 }
 ```
+As you can see the function must be declared `async` and must be exported as the root of the module.
 
-As you can see the function must be declared `async` and must be exported as the root of the module.  
+## Custom Status Routes
+With `lc39` your service will automatically inherit **two** fixed routes for getting infomation on the
+service:
+
+- `GET /-/healthz`
+- `GET /-/ready`
+
+The first route can be used as a probe for load balancers, status dashboards
+and as a [`helthinessProbe`][k8s-deployment-probes] for [Kubernetes][k8s].  
+By default, the route will always response with an `OK` status and the `200` `HTTP` code as soon as the service is up.
+
+The second route can be used as a [`readinessProbe`][k8s-deployment-probes] for Kubernetes.  
+As the first route, the default implementation of this endpoint will always respond
+`OK` status and the `200` `HTTP` code as soon as the service is up.
+
+The default implementations are a nice placeholder until you can add some logic tied to your service.  
+For doing so you can add two new `module.exports` to your main entrypoint that will be used instead of the defaults.
+
+```javascript
+module.exports.readinessHandler = function readinessHandler(request, reply) {
+  // Add your custom logic for /-/ready here
+}
+module.exports.healthinessHandler = function readinessHandler(request, reply) {
+  // Add your custom logic for /-/healthz here
+}
+```
+
+Both of these entpoint will be validated agains a JSON schema that you can find [here][status-routes-schema].  
+Additionally you will be able to access the variable `this.serviceName` to use it as the value of the `name`
+property in the response and it will default to the name of your service as set by `npm` or the one in
+`package.json`.
+
+**BE AWARE**  
+Both of this endpoints are set to permanently run on log level `silent` for decreasing the amount of noise in the logs during the
+deployment.
+
+[k8s]: https://kubernetes.io/
+[k8s-deployment-probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+[status-routes-schema]: ../lib/status-routes.schema.json

--- a/docs/main-entrypoint.md
+++ b/docs/main-entrypoint.md
@@ -33,25 +33,28 @@ As the first route, the default implementation of this endpoint will always resp
 `OK` status and the `200` `HTTP` code as soon as the service is up.
 
 The default implementations are a nice placeholder until you can add some logic tied to your service.  
-For doing so you can add two new `module.exports` to your main entrypoint that will be used instead of the defaults.
+For doing so you can add two new `module.exports` to your main entrypoint that will be used to customize
+the behavior.
 
 ```javascript
-module.exports.readinessHandler = function readinessHandler(request, reply) {
+module.exports.readinessHandler = async function readinessHandler(fastify) {
   // Add your custom logic for /-/ready here
 }
-module.exports.healthinessHandler = function healthinessHandler(request, reply) {
+module.exports.healthinessHandler = async function healthinessHandler(fastify) {
   // Add your custom logic for /-/healthz here
 }
 ```
 
 Both of these entpoint will be validated agains a JSON schema that you can find [here][status-routes-schema].  
-Additionally you will be able to access the variables `this.serviceName` and `this.serviceVersion`
-to use them as the value for the `name` and `version` properties in the response and
-they will default to the name and version of your service as set by `npm` or the ones in `package.json`.
+These functions must return an object that will customize the response of the server. The only property needed
+is `statusOK` that contains a boolean; `true` for returning a `200` response and `false` for returning `503`.  
+Additionally you can add any property you want and it will be appended to the response. If you add the `name`
+and/or `version` key your value will override the default ones that will parse your `package.json` to find
+the correct value.
 
 **BE AWARE**  
-Both of this endpoints are set to permanently run on log level `silent` for decreasing the amount of noise in the logs during the
-deployment.
+Both of this endpoints are set to permanently run on log level `silent` for decreasing the amount of noise in the
+logs during the deployment.
 
 [k8s]: https://kubernetes.io/
 [k8s-deployment-probes]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/

--- a/example/index.js
+++ b/example/index.js
@@ -29,6 +29,7 @@ module.exports.readinessHandler = function readinessHandler(request, reply) {
   const response = {
     name: this.serviceName,
     status: 'OK',
+    version: this.serviceVersion,
   }
 
   if (this.config.OPTIONAL_ENV <= 100) {
@@ -44,5 +45,6 @@ module.exports.healthinessHandler = function healthinessHandler(request, reply) 
   reply.send({
     name: 'everything-is-awesome',
     status: 'OK',
+    // avoid to set the version because it will not be read
   })
 }

--- a/example/index.js
+++ b/example/index.js
@@ -24,27 +24,22 @@ module.exports = async function service(fastify, options) {
   })
 }
 
-module.exports.readinessHandler = function readinessHandler(request, reply) {
-  let code = 200
+module.exports.readinessHandler = function readinessHandler(fastify) {
   const response = {
-    name: this.serviceName,
-    status: 'OK',
-    version: this.serviceVersion,
+    statusOK: true,
   }
 
-  if (this.config.OPTIONAL_ENV <= 100) {
-    code = 503
-    response.status = `Service is not ready, because the we have only ${this.config.OPTIONAL_ENV} points`
+  if (fastify.config.OPTIONAL_ENV <= 100) {
+    response.statusOK = false
+    response.message = `Service is not ready, because the we have only ${fastify.config.OPTIONAL_ENV} points`
   }
-  reply.code(code)
-  reply.send(response)
+
+  return response
 }
 
-module.exports.healthinessHandler = function healthinessHandler(request, reply) {
-  reply.code(200)
-  reply.send({
-    name: 'everything-is-awesome',
-    status: 'OK',
-    // avoid to set the version because it will not be read
-  })
+// eslint-disable-next-line no-unused-vars
+module.exports.healthinessHandler = function healthinessHandler(fastify) {
+  return {
+    statusOK: true,
+  }
 }

--- a/example/index.js
+++ b/example/index.js
@@ -23,3 +23,26 @@ module.exports = async function service(fastify, options) {
     })
   })
 }
+
+module.exports.readinessHandler = function readinessHandler(request, reply) {
+  let code = 200
+  const response = {
+    name: this.serviceName,
+    status: 'OK',
+  }
+
+  if (this.config.OPTIONAL_ENV <= 100) {
+    code = 503
+    response.status = `Service is not ready, because the we have only ${this.config.OPTIONAL_ENV} points`
+  }
+  reply.code(code)
+  reply.send(response)
+}
+
+module.exports.healthinessHandler = function healthinessHandler(request, reply) {
+  reply.code(200)
+  reply.send({
+    name: 'everything-is-awesome',
+    status: 'OK',
+  })
+}

--- a/lib/launch-fastify.js
+++ b/lib/launch-fastify.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Fastify = require('fastify')
+const fp = require('fastify-plugin')
 const absolutePath = require('./absolute-path')
 const customLogger = require('./custom-logger')
 const importEnv = require('./import-env')
@@ -59,8 +60,12 @@ async function launchFastify(file, options, address) {
   const logger = customLogger(moduleOptions, options)
   const fastify = new Fastify({ ...exportFastifyOptions(moduleOptions), logger })
 
-  fastify.register(statusRoutes, { serviceModule, prefix: '/-/', logLevel: 'silent' })
-  fastify.register(serviceModule, exportServiceOptions(options))
+  fastify
+    .register(statusRoutes, { serviceModule, prefix: '/-/', logLevel: 'silent' })
+    .after(() => {
+      fastify['_routePrefix'] = options.prefix || ''
+    })
+  fastify.register(fp(serviceModule), exportServiceOptions(options))
   await fastify.listen(options.port, address)
 
   return fastify

--- a/lib/launch-fastify.js
+++ b/lib/launch-fastify.js
@@ -5,6 +5,7 @@ const absolutePath = require('./absolute-path')
 const customLogger = require('./custom-logger')
 const importEnv = require('./import-env')
 const { exportFastifyOptions, exportServiceOptions } = require('./options-extractors')
+const statusRoutes = require('./status-routes')
 
 function importModule(filePath) {
   // disable the global require rule for importing the right module from the user given file
@@ -58,6 +59,7 @@ async function launchFastify(file, options, address) {
   const logger = customLogger(moduleOptions, options)
   const fastify = new Fastify({ ...exportFastifyOptions(moduleOptions), logger })
 
+  fastify.register(statusRoutes, { serviceModule, prefix: '/-/', logLevel: 'silent' })
   fastify.register(serviceModule, exportServiceOptions(options))
   await fastify.listen(options.port, address)
 

--- a/lib/status-routes.js
+++ b/lib/status-routes.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const packagePath = path.join(process.cwd(), 'package.json')
-const packageName = require(packagePath).name
+const { name, version } = require(packagePath)
 const statusRouteSchema = require('./status-routes.schema.json')
 
 function handleStatusRoute(request, reply) {
@@ -10,13 +10,15 @@ function handleStatusRoute(request, reply) {
   reply.send({
     name: this.serviceName,
     status: 'OK',
+    version: this.serviceVersion,
   })
 }
 
 module.exports = function statusRoutes(fastify, options, next) {
   const { healthinessHandler, readinessHandler } = options.serviceModule
 
-  fastify.decorate('serviceName', process.env.npm_package_name || packageName) // eslint-disable-line no-process-env
+  fastify.decorate('serviceName', process.env.npm_package_name || name) // eslint-disable-line no-process-env
+  fastify.decorate('serviceVersion', process.env.npm_package_version || version) // eslint-disable-line no-process-env
   fastify.route({
     method: 'GET',
     url: '/healthz',

--- a/lib/status-routes.js
+++ b/lib/status-routes.js
@@ -4,33 +4,55 @@ const path = require('path')
 const packagePath = path.join(process.cwd(), 'package.json')
 const { name, version } = require(packagePath)
 const statusRouteSchema = require('./status-routes.schema.json')
+const serviceName = process.env.npm_package_name || name // eslint-disable-line no-process-env
+const serviceVersion = process.env.npm_package_version || version // eslint-disable-line no-process-env
 
-function handleStatusRoute(request, reply) {
-  reply.type('application/json').code(200)
-  reply.send({
-    name: this.serviceName,
-    status: 'OK',
-    version: this.serviceVersion,
-  })
+async function handleStatusRoute(fastify, userHandler, request, reply) {
+  let statusResponse = {
+    statusOK: true,
+    name: serviceName,
+    version: serviceVersion,
+  }
+  if (userHandler) {
+    const userOverride = await userHandler(fastify)
+    statusResponse = {
+      ...statusResponse,
+      ...userOverride,
+    }
+  }
+
+  const { statusOK } = statusResponse
+  delete statusResponse.statusOK
+  delete statusResponse.status
+
+  const responseCode = statusOK ? 200 : 503
+  reply.type('application/json').code(responseCode)
+
+  const response = {
+    status: statusOK ? 'OK' : 'KO',
+    ...statusResponse,
+  }
+  reply.send(response)
 }
 
 module.exports = function statusRoutes(fastify, options, next) {
   const { healthinessHandler, readinessHandler } = options.serviceModule
-
-  fastify.decorate('serviceName', process.env.npm_package_name || name) // eslint-disable-line no-process-env
-  fastify.decorate('serviceVersion', process.env.npm_package_version || version) // eslint-disable-line no-process-env
   fastify.route({
     method: 'GET',
     url: '/healthz',
     schema: statusRouteSchema,
-    handler: healthinessHandler || handleStatusRoute,
+    handler: function handler(request, reply) {
+      handleStatusRoute(this, healthinessHandler, request, reply)
+    },
   })
 
   fastify.route({
     method: 'GET',
     url: '/ready',
     schema: statusRouteSchema,
-    handler: readinessHandler || handleStatusRoute,
+    handler: function handler(request, reply) {
+      handleStatusRoute(this, readinessHandler, request, reply)
+    },
   })
 
   next()

--- a/lib/status-routes.js
+++ b/lib/status-routes.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const path = require('path')
+const packagePath = path.join(process.cwd(), 'package.json')
+const packageName = require(packagePath).name
+const statusRouteSchema = require('./status-routes.schema.json')
+
+function handleStatusRoute(request, reply) {
+  reply.type('application/json').code(200)
+  reply.send({
+    name: this.serviceName,
+    status: 'OK',
+  })
+}
+
+module.exports = function statusRoutes(fastify, options, next) {
+  const { healthinessHandler, readinessHandler } = options.serviceModule
+
+  fastify.decorate('serviceName', process.env.npm_package_name || packageName) // eslint-disable-line no-process-env
+  fastify.route({
+    method: 'GET',
+    url: '/healthz',
+    schema: statusRouteSchema,
+    handler: healthinessHandler || handleStatusRoute,
+  })
+
+  fastify.route({
+    method: 'GET',
+    url: '/ready',
+    schema: statusRouteSchema,
+    handler: readinessHandler || handleStatusRoute,
+  })
+
+  next()
+}

--- a/lib/status-routes.schema.json
+++ b/lib/status-routes.schema.json
@@ -3,7 +3,8 @@
   "response": {
     "200": {
       "type": "object",
-      "required": ["status"],
+      "required": ["name", "status", "version"],
+      "additionalProperties": true,
       "properties": {
         "name": {
           "type": "string",
@@ -22,7 +23,8 @@
     },
     "503": {
       "type": "object",
-      "required": ["status"],
+      "required": ["name", "status", "version"],
+      "additionalProperties": true,
       "properties": {
         "name": {
           "type": "string",
@@ -30,7 +32,8 @@
         },
         "status": {
           "type": "string",
-          "description": "It's status, it can be KO, or a human readable reason for failure"
+          "description": "It\"s status, it must be KO",
+          "enum": ["KO"]
         },
         "version": {
           "type": "string",

--- a/lib/status-routes.schema.json
+++ b/lib/status-routes.schema.json
@@ -1,0 +1,34 @@
+{
+  "hide": true,
+  "response": {
+    "200": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the current service that has responded"
+        },
+        "status": {
+          "type": "string",
+          "description": "It\"s status, it must be OK",
+          "enum": ["OK"]
+        }
+      }
+    },
+    "503": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the current service that has responded"
+        },
+        "status": {
+          "type": "string",
+          "description": "It's status, it can be KO, or a human readable reason for failure"
+        }
+      }
+    }
+  }
+}

--- a/lib/status-routes.schema.json
+++ b/lib/status-routes.schema.json
@@ -13,6 +13,10 @@
           "type": "string",
           "description": "It\"s status, it must be OK",
           "enum": ["OK"]
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the service that is running expressed as semver"
         }
       }
     },
@@ -27,6 +31,10 @@
         "status": {
           "type": "string",
           "description": "It's status, it can be KO, or a human readable reason for failure"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the service that is running expressed as semver"
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,6 +1255,14 @@
         }
       }
     },
+    "fastify-plugin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.4.0.tgz",
+      "integrity": "sha512-l6uqDyBp3gBjLQRAi3j2NwSvlbe9LuqULZugnO9iRFfYHWd2SpsZBLI1l4Jakk0VMGfYlB322JPIPYh/2qSHig==",
+      "requires": {
+        "semver": "^5.5.0"
+      }
+    },
     "fastq": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
@@ -5142,8 +5150,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-store": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dotenv": "^6.2.0",
     "dotenv-expand": "^4.2.0",
     "fastify": "^1.13.3",
+    "fastify-plugin": "^1.4.0",
     "make-promises-safe": "^4.0.0",
     "pino": "^5.10.6"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "postcoverage": "tap --coverage-report=html --no-browser",
     "lint": "standard-mia | snazzy",
     "test": "npm run lint && npm run unit",
-    "unit": "tap -b -o tap.log tests/*.test.js"
+    "unit": "tap -b -o tap.log tests/*.test.js",
+    "version": "./scripts/update-version.sh ${npm_package_version} && git add CHANGELOG.md"
   },
   "dependencies": {
     "commander": "^2.19.0",

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+umask 077
+
+# Automatically get the folder where the source files must be placed.
+__DIR=$(dirname "${0}")
+SOURCE_DIR="${__DIR}/../"
+TAG_VALUE="${1}"
+
+# Create a variable that contains the current date in UTC
+# Different flow if this script is running on Darwin or Linux machines.
+if [ "$(uname)" = "Darwin" ]; then
+  NOW_DATE="$(date -u +%F)"
+else
+  NOW_DATE="$(date -u -I)"
+fi
+
+sed -i.bck "s|### TBR|### v${TAG_VALUE} (${NOW_DATE})|g" "${SOURCE_DIR}/CHANGELOG.md"
+rm -fr ${SOURCE_DIR}/CHANGELOG.md.bck

--- a/tests/modules/custom-routes.js
+++ b/tests/modules/custom-routes.js
@@ -4,25 +4,23 @@
 
 // eslint-disable-next-line require-await
 module.exports = async function plugin(fastify, config) {
+  fastify.decorate('customProperty', 'custom-values')
   fastify.get('/', function returnConfig(request, reply) {
     reply.send({ config })
   })
 }
 
-module.exports.readinessHandler = function readinessHandler(request, reply) {
-  reply.code(503)
-  reply.send({
-    name: this.serviceName,
-    status: 'Not ready to respond',
-    version: this.serviceVersion,
-  })
+module.exports.readinessHandler = function readinessHandler(server) {
+  return {
+    statusOK: false,
+    customProperty: server.customProperty,
+  }
 }
 
-module.exports.healthinessHandler = function healthinessHandler(request, reply) {
-  reply.code(200)
-  reply.send({
+module.exports.healthinessHandler = function healthinessHandler() {
+  return {
+    statusOK: true,
+    status: 'KO',
     name: 'Override with custom name',
-    status: 'OK',
-    version: this.serviceVersion,
-  })
+  }
 }

--- a/tests/modules/custom-routes.js
+++ b/tests/modules/custom-routes.js
@@ -14,6 +14,7 @@ module.exports.readinessHandler = function readinessHandler(request, reply) {
   reply.send({
     name: this.serviceName,
     status: 'Not ready to respond',
+    version: this.serviceVersion,
   })
 }
 
@@ -22,5 +23,6 @@ module.exports.healthinessHandler = function healthinessHandler(request, reply) 
   reply.send({
     name: 'Override with custom name',
     status: 'OK',
+    version: this.serviceVersion,
   })
 }

--- a/tests/modules/custom-routes.js
+++ b/tests/modules/custom-routes.js
@@ -1,0 +1,26 @@
+/* istanbul ignore file */
+
+'use strict'
+
+// eslint-disable-next-line require-await
+module.exports = async function plugin(fastify, config) {
+  fastify.get('/', function returnConfig(request, reply) {
+    reply.send({ config })
+  })
+}
+
+module.exports.readinessHandler = function readinessHandler(request, reply) {
+  reply.code(503)
+  reply.send({
+    name: this.serviceName,
+    status: 'Not ready to respond',
+  })
+}
+
+module.exports.healthinessHandler = function healthinessHandler(request, reply) {
+  reply.code(200)
+  reply.send({
+    name: 'Override with custom name',
+    status: 'OK',
+  })
+}

--- a/tests/status-routes.test.js
+++ b/tests/status-routes.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const launch = require('../lib/launch-fastify')
+const packageVersion = require('../package.json').version
 
 test('Test Fastify creation with standard status routes', async assert => {
   const options = {
@@ -21,6 +22,7 @@ test('Test Fastify creation with standard status routes', async assert => {
   assert.strictSame(JSON.parse(healthResponse.payload), {
     name: '@mia-platform/lc39',
     status: 'OK',
+    version: packageVersion,
   })
 
   const readyResponse = await fastifyInstance.inject({
@@ -33,6 +35,7 @@ test('Test Fastify creation with standard status routes', async assert => {
   assert.strictSame(JSON.parse(readyResponse.payload), {
     name: '@mia-platform/lc39',
     status: 'OK',
+    version: packageVersion,
   })
 
   await fastifyInstance.close()
@@ -45,8 +48,11 @@ test('Test Fastify creation with custom status routes', async assert => {
     port: 3000,
   }
 
+  // A terrible hack for simulating the project running without npm
   const npmPackageName = process.env.npm_package_name // eslint-disable-line no-process-env
+  const npmPackageVersion = process.env.npm_package_version // eslint-disable-line no-process-env
   delete process.env.npm_package_name // eslint-disable-line no-process-env
+  delete process.env.npm_package_version // eslint-disable-line no-process-env
   const fastifyInstance = await launch('./tests/modules/custom-routes', options)
 
   const healthResponse = await fastifyInstance.inject({
@@ -59,6 +65,7 @@ test('Test Fastify creation with custom status routes', async assert => {
   assert.strictSame(JSON.parse(healthResponse.payload), {
     name: 'Override with custom name',
     status: 'OK',
+    version: packageVersion,
   })
 
   const readyResponse = await fastifyInstance.inject({
@@ -71,9 +78,12 @@ test('Test Fastify creation with custom status routes', async assert => {
   assert.strictSame(JSON.parse(readyResponse.payload), {
     name: '@mia-platform/lc39',
     status: 'Not ready to respond',
+    version: packageVersion,
   })
 
   await fastifyInstance.close()
+  // Undo the hack
   process.env.npm_package_name = npmPackageName // eslint-disable-line no-process-env
+  process.env.npm_package_version = npmPackageVersion // eslint-disable-line no-process-env
   assert.end()
 })

--- a/tests/status-routes.test.js
+++ b/tests/status-routes.test.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const { test } = require('tap')
+const launch = require('../lib/launch-fastify')
+
+test('Test Fastify creation with standard status routes', async assert => {
+  const options = {
+    logLevel: 'silent',
+    port: 3000,
+  }
+
+  const fastifyInstance = await launch('./tests/modules/correct-module', options)
+
+  const healthResponse = await fastifyInstance.inject({
+    method: 'GET',
+    url: '/-/healthz',
+  })
+
+  assert.strictSame(healthResponse.statusCode, 200)
+  assert.strictSame(healthResponse.headers['content-type'], 'application/json; charset=utf-8')
+  assert.strictSame(JSON.parse(healthResponse.payload), {
+    name: '@mia-platform/lc39',
+    status: 'OK',
+  })
+
+  const readyResponse = await fastifyInstance.inject({
+    method: 'GET',
+    url: '/-/ready',
+  })
+
+  assert.strictSame(readyResponse.statusCode, 200)
+  assert.strictSame(healthResponse.headers['content-type'], 'application/json; charset=utf-8')
+  assert.strictSame(JSON.parse(readyResponse.payload), {
+    name: '@mia-platform/lc39',
+    status: 'OK',
+  })
+
+  await fastifyInstance.close()
+  assert.end()
+})
+
+test('Test Fastify creation with custom status routes', async assert => {
+  const options = {
+    logLevel: 'silent',
+    port: 3000,
+  }
+
+  const fastifyInstance = await launch('./tests/modules/custom-routes', options)
+
+  const healthResponse = await fastifyInstance.inject({
+    method: 'GET',
+    url: '/-/healthz',
+  })
+
+  assert.strictSame(healthResponse.statusCode, 200)
+  assert.strictSame(healthResponse.headers['content-type'], 'application/json; charset=utf-8')
+  assert.strictSame(JSON.parse(healthResponse.payload), {
+    name: 'Override with custom name',
+    status: 'OK',
+  })
+
+  const readyResponse = await fastifyInstance.inject({
+    method: 'GET',
+    url: '/-/ready',
+  })
+
+  assert.strictSame(readyResponse.statusCode, 503)
+  assert.strictSame(healthResponse.headers['content-type'], 'application/json; charset=utf-8')
+  assert.strictSame(JSON.parse(readyResponse.payload), {
+    name: '@mia-platform/lc39',
+    status: 'Not ready to respond',
+  })
+
+  await fastifyInstance.close()
+  assert.end()
+})

--- a/tests/status-routes.test.js
+++ b/tests/status-routes.test.js
@@ -77,8 +77,9 @@ test('Test Fastify creation with custom status routes', async assert => {
   assert.strictSame(healthResponse.headers['content-type'], 'application/json; charset=utf-8')
   assert.strictSame(JSON.parse(readyResponse.payload), {
     name: '@mia-platform/lc39',
-    status: 'Not ready to respond',
+    status: 'KO',
     version: packageVersion,
+    customProperty: 'custom-values',
   })
 
   await fastifyInstance.close()

--- a/tests/status-routes.test.js
+++ b/tests/status-routes.test.js
@@ -45,6 +45,8 @@ test('Test Fastify creation with custom status routes', async assert => {
     port: 3000,
   }
 
+  const npmPackageName = process.env.npm_package_name // eslint-disable-line no-process-env
+  delete process.env.npm_package_name // eslint-disable-line no-process-env
   const fastifyInstance = await launch('./tests/modules/custom-routes', options)
 
   const healthResponse = await fastifyInstance.inject({
@@ -72,5 +74,6 @@ test('Test Fastify creation with custom status routes', async assert => {
   })
 
   await fastifyInstance.close()
+  process.env.npm_package_name = npmPackageName // eslint-disable-line no-process-env
   assert.end()
 })


### PR DESCRIPTION
This pull request will add two new route by default to all the services launched with lc39:

- `/-/ready`
- `/-/healthz`

I have chosen the `/-/` prefix because it's a very uncommon one, other services has adopted a similar prefix for their status endpoints, and is a prefix that is not allowed to be used from the services launched with lc39 avoiding potential conflicts.

I’m not so sure on `healthz`... Is the one that I see more often a a de facto standard for load balancing health checks (for gce is the default one for their cloud balancer) but I don’t like it very much.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or intregrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
