### PR TITLE
Log improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add custom serializers for logging requests, responses and errors key inside the logs
+- Add customization for the stream property of the logger during tests
+
 ### Changed
 
-- Update commander 2.20.0 -> 3.0.2
+- Update commander 2.20.0 -> 5.0.0
 - Update dotenv 8.0.0 -> 8.2.1
 - Update fastify 2.11.0 -> 2.12.1
 - Update fastify-plugin 1.6.0 -> 1.6.1
@@ -34,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated status routes log level to error instead of silent (unless silent is provided from configuration).
+- Updated status routes log level to error instead of silent
+  (unless silent is provided from configuration).
 
 ## v2.2.2 - 2019-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update commander 2.20.0 -> 5.0.0
 - Update dotenv 8.0.0 -> 8.2.1
-- Update fastify 2.11.0 -> 2.12.1
+- Update fastify 2.11.0 -> 2.13.0
 - Update fastify-plugin 1.6.0 -> 1.6.1
 - Update fastify-swagger 2.4.0 -> 2.5.0
 - Update make-promises-safe 5.0.0 -> 5.1.0

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,7 +37,7 @@ program
   .option('-e, --env-path [envFile]', 'the env file path')
   .parse(process.argv)
 
-if (!program.args.length) {
+if (program.rawArgs.length < 3) {
   return program.help()
 }
 

--- a/docs/development-affordance.md
+++ b/docs/development-affordance.md
@@ -1,6 +1,6 @@
 # Development Affordance
 
-To iad you in the development and testing of your service locally on your machine we provide
+To aid you in the development and testing of your service locally on your machine we provide
 some affordances that you can use.
 
 ## `ENV` Variables for Local Runs
@@ -85,6 +85,30 @@ From the `fastify` variable returned you can then customized it for your tests a
 By default the started instance is not listening on any port and will start the logger at the `silent` level.  
 If you need to see the log you can set the `logLevel` key inside the `options` object and you are free to bind the
 fastify instance on any address and port using its available methods.
+
+## Capture the Log Stream
+
+In some cases during the tests you want to capture the logs emitted from the logger and do actions on them. For this
+cases you can set the `stream` key that accept a writable stream. Once written the data is at your disposal, the simplest
+stream you can use is the `PassThrough` stream of node:
+
+```javascript
+const { PassThrough } = require('stream')
+const lc39 = require('@mia-platform/lc39')
+const test = require('tap').test
+
+test('A simple test', async assert => {
+  const stream = new PassThrough()
+  const options {
+    logLevel: 'info',
+    stream,
+  }
+  
+  const fastify = await lc39('./path/to/entrypoint/from/root', options)
+  const log = stream.read().toString()
+  ...
+})
+```
 
 [dotenv-file-syntax]: https://www.npmjs.com/package/dotenv#rules
 [fastify-env]: https://github.com/fastify/fastify-env

--- a/docs/service-options.md
+++ b/docs/service-options.md
@@ -17,7 +17,7 @@ module.exports.options = {
 The values supported in this object are the supported keys and value for the Fastify server instance
 that you can find at this [link][fastify-server-options]; with the exception of the `logger` parameter.  
 Instead you can customize the `pino` instance via the `logLevel` key and you can modify the redaction rules
-via the `redact` key. For this key the accepted values listed [here][pino-redact-options].  
+via the `redact` key. For this key the accepted values are listed [here][pino-redact-options].  
 You have an additional key, `errorHandler` that is passed to the `fastify-sensible` plugin;
 its usage can be found [here][fastify-sensible-error-handler].
 

--- a/example/package.json
+++ b/example/package.json
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@mia-platform/lc39": "mia-platform/lc39",
-    "fastify-env": "^0.6.1"
+    "fastify-env": "^1.0.1"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }

--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -21,15 +21,53 @@
 // we don't want to see emails, usernames and passwords even if crypted and/or hashed
 function defaultRedactionRules() {
   return {
-    paths: ['email', 'password', 'username', '[*].email', '[*].password', '[*].username'],
+    paths: [
+      'email',
+      'password',
+      'username',
+      'debugInfo.email',
+      'debugInfo.password',
+      'debugInfo.username',
+      'debugInfo[*].email',
+      'debugInfo[*].password',
+      'debugInfo[*].username',
+    ],
     censor: '[REDACTED]',
   }
 }
 
+function timestampFunction() {
+  return `,"time":${Date.now() / 1000.0}`
+}
+
 function pinoOptions(moduleOptions, options) {
+  const stream = options.stream ? { stream: options.stream } : {}
   return {
     level: options.logLevel || moduleOptions.logLevel || 'info',
     redact: moduleOptions.redact || defaultRedactionRules(),
+    ...stream,
+    serializers: {
+      req: requestSerializer,
+      res: responseSerializer,
+    },
+    timestamp: timestampFunction,
+  }
+}
+
+function requestSerializer(request) {
+  return {
+    requestMethod: request.method,
+    requestURL: request.url,
+    userAgent: request.headers['user-agent'],
+    hostname: request.hostname,
+    remoteAddress: request.ip,
+  }
+}
+
+function responseSerializer(response) {
+  return {
+    statusCode: response.statusCode,
+    responseSize: response.getHeader('content-length'),
   }
 }
 
@@ -38,3 +76,6 @@ module.exports = function customLogger(moduleOptions, options) {
 }
 
 module.exports.pinoOptions = pinoOptions
+module.exports.requestSerializer = requestSerializer
+module.exports.responseSerializer = responseSerializer
+module.exports.timestampFunction = timestampFunction

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "version": "./scripts/update-version.sh ${npm_package_version} && git add CHANGELOG.md"
   },
   "dependencies": {
-    "commander": "^3.0.2",
+    "commander": "^5.0.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
     "fastify": "^2.12.1",
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^2.0.1",
     "eslint": "^6.8.0",
+    "split2": "^3.1.1",
     "tap": "^14.10.6"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "commander": "^5.0.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
-    "fastify": "^2.12.1",
+    "fastify": "^2.13.0",
     "fastify-plugin": "^1.6.1",
     "fastify-sensible": "^2.1.1",
     "fastify-swagger": "^2.5.0",

--- a/tests/custom-logger.test.js
+++ b/tests/custom-logger.test.js
@@ -18,6 +18,7 @@
 
 const { test } = require('tap')
 const customLogger = require('../lib/custom-logger')
+const { requestSerializer, responseSerializer, timestampFunction } = require('../lib/custom-logger')
 
 test('Test generation for custom logger', assert => {
   const moduleOptions = {}
@@ -48,11 +49,19 @@ test('Test generation custom logger default options', assert => {
         'email',
         'password',
         'username',
-        '[*].email',
-        '[*].password',
-        '[*].username',
+        'debugInfo.email',
+        'debugInfo.password',
+        'debugInfo.username',
+        'debugInfo[*].email',
+        'debugInfo[*].password',
+        'debugInfo[*].username',
       ],
     },
+    serializers: {
+      req: requestSerializer,
+      res: responseSerializer,
+    },
+    timestamp: timestampFunction,
   })
 
   assert.end()
@@ -68,7 +77,7 @@ test('Test generation custom logger default options', assert => {
       censor: '[BRACE YOURSELF, GDPR IS COMING]',
       paths: [
         'veryPrivate',
-        'suchIntresting.[*].howToHide',
+        'suchIntresting[*].howToHide',
       ],
     },
     logLevel: 'overwritten',
@@ -78,6 +87,11 @@ test('Test generation custom logger default options', assert => {
   assert.strictSame(pinoOptions, {
     level: options.logLevel,
     redact: moduleOptions.redact,
+    serializers: {
+      req: requestSerializer,
+      res: responseSerializer,
+    },
+    timestamp: timestampFunction,
   })
 
   assert.end()

--- a/tests/launch-fastify.test.js
+++ b/tests/launch-fastify.test.js
@@ -141,15 +141,18 @@ test('Test fail Fastify creation for invalid options', assert => {
   assert.end()
 })
 
-test('Log level inheriting system', async assert => {
-  assert.plan(3)
-  const stream = split(JSON.parse)
-  let fastifyInstance = await launch('./tests/modules/module-with-log', {})
+test('Log level inheriting system with a custom setting', async assert => {
+  assert.plan(1)
+  const fastifyInstance = await launch('./tests/modules/module-with-log', {})
   assert.strictSame(fastifyInstance.log.level, launch.importModule('./tests/modules/module-with-log').options.logLevel)
   await fastifyInstance.close()
+})
 
-  // intercept the stream to check if something is written on it
-  fastifyInstance = await launch('./tests/modules/correct-module', {
+test('Log level inheriting system with defaults checking data are properly streamed', async assert => {
+  assert.plan(2)
+
+  const stream = split(JSON.parse)
+  const fastifyInstance = await launch('./tests/modules/correct-module', {
     stream,
   })
   assert.strictSame(fastifyInstance.log.level, 'info')


### PR DESCRIPTION
This pull request will enable two new custom data serializer for the res and req key used by fastify and enable the customization of the stream on which pino will write its logs in order to been able to act on them during tests.

The customizations to the serializers are mainly on the keywords name to uniform them between different logs and it will add the response dimension value.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or intregrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data