### PR TITLE
CHANGE(BMP-508): get content-length header from fastify response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.1.1 - 2020-09-22
+## Unreleased
+
+### Fixed
+
+  - [BMP-508](https://makeitapp.atlassian.net/browse/BMP-508): replaced `reply.res.getHeader('content-length')` with `reply.getHeader('content-length')` in order to get `content-length` header.
 
 ## 3.1.1 - 2020-09-22
 

--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -74,7 +74,7 @@ function logRequestCompleted(req, reply, next) {
       response: {
         statusCode,
         body: {
-          bytes: reply.res.getHeader('content-length'),
+          bytes: reply.getHeader('content-length'),
         },
       },
     },


### PR DESCRIPTION
Now in order to get the content-length header we use `reply.getHeader('content-length')` of [Fastify](https://www.fastify.io/docs/v2.0.x/Reply/) instead of `reply.res.getHeader('content-length')` of [Node](https://nodejs.org/dist/latest/docs/api/http.html#http_class_http_serverresponse)

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [X] tests are included
- [ ] the documentation is updated or intregrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
