### PR TITLE
ADD(BMP-508): added forwardedHostname and modified ip and hostname values in request and response

### DIFF
--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -40,8 +40,13 @@ function pinoOptions(moduleOptions, options) {
   }
 }
 
+function removePort(host) {
+  const hostname = host.split(':')
+  return hostname[0]
+}
+
 function logIncomingRequest(req, reply, next) {
-  const { req: { method, url }, headers, hostname, ip } = req
+  const { req: { method, url }, headers } = req
   req.log.trace({
     http: {
       request: {
@@ -53,15 +58,16 @@ function logIncomingRequest(req, reply, next) {
     },
     url: { path: url },
     host: {
-      hostname,
-      ip,
+      hostname: removePort(headers['host']),
+      forwardedHostame: headers['x-forwarded-host'],
+      ip: headers['x-forwarded-for'],
     },
   }, 'incoming request')
   next()
 }
 
 function logRequestCompleted(req, reply, next) {
-  const { req: { method, url }, headers, hostname, ip } = req
+  const { req: { method, url }, headers } = req
   const { res: { statusCode } } = reply
   req.log.info({
     http: {
@@ -80,8 +86,9 @@ function logRequestCompleted(req, reply, next) {
     },
     url: { path: url },
     host: {
-      hostname,
-      ip,
+      hostname: removePort(headers['host']),
+      forwardedHostame: headers['x-forwarded-host'],
+      ip: headers['x-forwarded-for'],
     },
     responseTime: reply.getResponseTime(),
   }, 'request completed')

--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -41,6 +41,9 @@ function pinoOptions(moduleOptions, options) {
 }
 
 function removePort(host) {
+  if (!host) {
+    return undefined
+  }
   const hostname = host.split(':')
   return hostname[0]
 }

--- a/tests/launch-fastify.test.js
+++ b/tests/launch-fastify.test.js
@@ -188,7 +188,7 @@ test('Test custom serializers', async assert => {
         },
       })
       assert.strictSame(line.url, { path: '/' })
-      assert.strictSame(line.host, { hostname: 'localhost:80', ip: '127.0.0.1' })
+      assert.strictSame(line.host, { hostname: 'testHost', forwardedHostame: 'testForwardedHost', ip: 'testIp' })
 
       stream.once('data', secondLine => {
         assert.equal(line.reqId, 1)
@@ -206,7 +206,7 @@ test('Test custom serializers', async assert => {
           },
         })
         assert.strictSame(secondLine.url, { path: '/' })
-        assert.strictSame(secondLine.host, { hostname: 'localhost:80', ip: '127.0.0.1' })
+        assert.strictSame(secondLine.host, { hostname: 'testHost', forwardedHostame: 'testForwardedHost', ip: 'testIp' })
 
         assert.end()
       })
@@ -220,6 +220,11 @@ test('Test custom serializers', async assert => {
   await fastifyInstance.inject({
     method: 'GET',
     url: '/',
+    headers: {
+      'x-forwarded-for': 'testIp',
+      'host': 'testHost:3000',
+      'x-forwarded-host': 'testForwardedHost',
+    },
   })
 
   await fastifyInstance.close()


### PR DESCRIPTION
Modified lc39 logs in order to show the forwarded host, the hostname (taking it from `host` header) and the ip (taking it from `x-forwarded-for` header).

[BMP-508](https://makeitapp.atlassian.net/browse/BMP-508)

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [X] tests are included
- [ ] the documentation is updated or intregrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
