### PR TITLE
feat(BMP-828): timestamp with millisecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- [BMP-828](https://makeitapp.atlassian.net/browse/BMP-828): log timestamp shows milliseconds instead of only seconds.
+
 ## v4.0.0-rc.0 - 2020-12-21
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [BMP-828](https://makeitapp.atlassian.net/browse/BMP-828): log timestamp has precision in milliseconds instead of seconds.
+- log timestamp has precision in milliseconds instead of seconds.
 
 ## v4.0.0-rc.0 - 2020-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [BMP-828](https://makeitapp.atlassian.net/browse/BMP-828): log timestamp shows milliseconds instead of only seconds.
+- [BMP-828](https://makeitapp.atlassian.net/browse/BMP-828): log timestamp has precision in milliseconds instead of seconds.
 
 ## v4.0.0-rc.0 - 2020-12-21
 

--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -27,7 +27,8 @@ function defaultRedactionRules() {
 }
 
 function timestampFunction() {
-  return `,"time":${Math.round(Date.now() / 1000.0)}`
+  // console.log('time: ', Math.round(Date.now()))
+  return `,"time":${Math.round(Date.now())}`
 }
 
 function pinoOptions(moduleOptions, options) {

--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -27,7 +27,6 @@ function defaultRedactionRules() {
 }
 
 function timestampFunction() {
-  // console.log('time: ', Math.round(Date.now()))
   return `,"time":${Math.round(Date.now())}`
 }
 

--- a/tests/custom-logger.test.js
+++ b/tests/custom-logger.test.js
@@ -85,3 +85,12 @@ test('Test generation custom logger default options', assert => {
 
   assert.end()
 })
+
+test('Test timestamp generation in milliseconds', assert => {
+  const [, timestampString] = timestampFunction().split(':')
+  const millisecondTimestampMagnitude = 1e12
+
+  assert.ok(parseInt(timestampString, 10) > millisecondTimestampMagnitude)
+
+  assert.end()
+})

--- a/tests/custom-logger.test.js
+++ b/tests/custom-logger.test.js
@@ -87,10 +87,11 @@ test('Test generation custom logger default options', assert => {
 })
 
 test('Test timestamp generation in milliseconds', assert => {
+  const recentYear = 2021
   const [, timestampString] = timestampFunction().split(':')
-  const millisecondTimestampMagnitude = 1e12
+  const dateFromTimestamp = new Date(parseInt(timestampString, 10))
 
-  assert.ok(parseInt(timestampString, 10) > millisecondTimestampMagnitude)
+  assert.ok(dateFromTimestamp.getFullYear() >= recentYear)
 
   assert.end()
 })


### PR DESCRIPTION
Now timestamps show the time elapsed since January 1st 1970 in milliseconds.

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [x] tests are included
- [ ] the documentation is updated or intregrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
