### PR TITLE
Fix metrics route log level

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -23,7 +23,7 @@ const envSchema = {
   required: ['TEST_ENV'],
   properties: {
     TEST_ENV: { type: 'string', description: 'a test env variable' },
-    OPTIONAL_ENV: { type: 'number', decription: 'a test optional env variable', default: 100 },
+    OPTIONAL_ENV: { type: 'number', description: 'a test optional env variable', default: 100 },
   },
   additionalProperties: false,
 }

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@mia-platform/lc39": "mia-platform/lc39",
-    "fastify-env": "^1.0.1"
+    "fastify-env": "^2.1.1"
   },
   "engines": {
     "node": ">=8"

--- a/lib/metrics-routes.js
+++ b/lib/metrics-routes.js
@@ -20,7 +20,7 @@ const fastifyMetrics = require('fastify-metrics')
 const prometheusClient = require('prom-client')
 
 module.exports = function metricsRoutes(fastify, options, next) {
-  const { serviceModule, metricsOptions } = options
+  const { serviceModule, metricsOptions, logLevel } = options
   const { getMetrics } = serviceModule
 
   prometheusClient.register.clear()
@@ -30,6 +30,7 @@ module.exports = function metricsRoutes(fastify, options, next) {
   fastify.register(fastifyMetrics, {
     ...metricsOptions,
     endpoint: '/-/metrics',
+    logLevel,
   })
 
   next()

--- a/package.json
+++ b/package.json
@@ -42,18 +42,18 @@
     "commander": "^7.2.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
-    "fastify": "^3.18.0",
-    "fastify-metrics": "^7.1.0",
+    "fastify": "^3.20.2",
+    "fastify-metrics": "^7.2.3",
     "fastify-plugin": "^3.0.0",
     "fastify-sensible": "^3.1.1",
-    "fastify-swagger": "^4.6.0",
+    "fastify-swagger": "^4.9.0",
     "make-promises-safe": "^5.1.0",
-    "prom-client": "^13.1.0"
+    "prom-client": "^13.2.0"
   },
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^3.0.0",
-    "ajv": "^6.12.5",
-    "eslint": "^7.24.0",
+    "ajv": "^6.12.6",
+    "eslint": "^7.32.0",
     "split2": "^3.2.2",
     "tap": "^15.0.9"
   },


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

### Issue

The `/-/metrics` route is set to follow the same log level of status routes (`/-/healthz`, `/-/ready`, `/-/checkup`). However, due to a missing parameter, the `/-/metrics` endpoints follows instead the default service log level (which is _info_).  
This pollutes logs at _info_ level with unnecessary records.

### Solution

The proposed solution is to extract the intended `logLevel` from the given options and provide it to the `fastify.register()` function.

In addition:
 - the plugin example has been fixed, so that it can be run to check that requesting the `/-/metrics` route does not produce logs at _info_ level
 - dependencies whose upgrade was non-breaking were updated

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes (provided changes do not require to be documented)
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
