### PR TITLE
Fix ts types export

### DIFF
--- a/lc39.d.ts
+++ b/lc39.d.ts
@@ -16,18 +16,11 @@
 
 import { LogLevel, FastifyInstance } from 'fastify'
 
-interface environmentSchema {
-  type: 'object',
-  required?: string[],
-  properties: object
-}
-
 interface launchOptions {
-  prefix?: string,
-  logLevel?: LogLevel,
-  envVariables?: environmentSchema,
+  logLevel?: LogLevel | 'silent',
+  envVariables?: Record<string, string>,
 }
 
-declare function lc39(filePath:string, options?: launchOptions): FastifyInstance
+declare function lc39(filePath:string, options?: launchOptions): Promise<FastifyInstance>
 
 export default lc39

--- a/test-d/index.d-test.ts
+++ b/test-d/index.d-test.ts
@@ -5,4 +5,4 @@ import lc39 from '../'
 
 const server = lc39('../tests/modules/correct-module.js')
 
-expectType<FastifyInstance>(server)
+expectType<Promise<FastifyInstance>>(server)


### PR DESCRIPTION
Modified definition of parameters and return type for lc39 function, in order to prevent errors in ts template that depends on lc39.
I have also changed the test concerning the expected type of the function lc39.

#### Checklist

- [ x ] your branch will not cause merge conflict with `master`
- [ x ] run `npm test`
- [ x ] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [ x ] the code will follow the lint rules and style of the project
- [ x ] you are not committing extraneous files or sensible data
