### PR TITLE
Update log redaction rules

### DIFF
--- a/lib/custom-logger.js
+++ b/lib/custom-logger.js
@@ -25,8 +25,8 @@ function defaultRedactionRules() {
       'email', '[*].email',
       'password', '[*].password',
       'username', '[*].username',
-      'authorization', '[*].authorization',
-      'cookie', '[*].cookie',
+      'authorization', 'Authorization', '[*].authorization', '[*].Authorization',
+      'cookie', 'Cookie', '[*].cookie', '[*].Cookie',
     ],
     censor: '[REDACTED]',
   }

--- a/tap-snapshots/tests/custom-logger.test.js.test.cjs
+++ b/tap-snapshots/tests/custom-logger.test.js.test.cjs
@@ -5,6 +5,17 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`tests/custom-logger.test.js TAP Test redacted values - uppercase headers > must match snapshot 1`] = `
+Array [
+  Object {
+    "headersToSend": Object {
+      "Authorization": "[REDACTED]",
+      "Cookie": "[REDACTED]",
+    },
+  },
+]
+`
+
 exports[`tests/custom-logger.test.js TAP Test redacted values > must match snapshot 1`] = `
 Array [
   Object {

--- a/tests/modules/correct-module.js
+++ b/tests/modules/correct-module.js
@@ -72,6 +72,15 @@ module.exports = async function plugin(fastify, config) {
     this.log.info({ headers: request.headers, requestBody: request.body })
     reply.send({})
   })
+
+  fastify.post('/with-logs-uppercase', function handler(request, reply) {
+    const headersToSend = {
+      Authorization: 'Bearer my token',
+      Cookie: request.headers.cookie,
+    }
+    this.log.info({ headersToSend })
+    reply.send({})
+  })
 }
 
 const redactionRules = logDefaultRedactionRules()


### PR DESCRIPTION
For example in [custom-plugin-lib](https://github.com/mia-platform/custom-plugin-lib/blob/master/lib/httpClient.js#L95), the logger logs also API request headers. Those headers are set by user, and it could be a standard use case to name the header  with capitalization. So, for example, set `headers.Cookie`. [pino redaction](https://getpino.io/#/docs/redaction?id=path-syntax) is path sensitive.
So, I suggest to also add capitalization redaction for authorization and cookie.

What do you think about?

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
