### PR TITLE
Add custom logging hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v7.2.0
+
+* add custom hooks
+
+## v7.1.0 - 2024-02-16
+
 * add custom log level
 
 ## v7.0.3 - 2023-11-30

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -3,11 +3,11 @@
 The **lc39** cli command support some degree of personalization via command flags.  
 Here are listed all the available flags, their default values and the accepted ones.
 
-|  Description | Short Command | Full Command | Default Value |
-| ------------ | ------------- |--------------| ------------- |
-| Port to listen on | `-p` | `--port` | `3000` |
-| Log level | `-l` | `--log-level` | `info` |
-| Set the prefix | `-x` | `--prefix` |  |
-| The path of the dotenv file to load during launch | `-e` | `--env-path` |  |
-| Expose Prometheus metrics |  | `--expose-metrics` | `true`  |
-| Enable tracing            |  | `--enable-tracing` | `false` |
+| Description                                       | Short Command | Full Command       | Default Value |
+|---------------------------------------------------|---------------|--------------------|---------------|
+| Port to listen on                                 | `-p`          | `--port`           | `3000`        |
+| Log level                                         | `-l`          | `--log-level`      | `info`        |
+| Set the prefix                                    | `-x`          | `--prefix`         |               |
+| The path of the dotenv file to load during launch | `-e`          | `--env-path`       |               |
+| Expose Prometheus metrics                         |               | `--expose-metrics` | `true`        |
+| Enable tracing                                    |               | `--enable-tracing` | `false`       |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,7 +2,7 @@
 
 The library generates logs following [Mia-Platform logging guidelines](https://docs.mia-platform.eu/docs/development_suite/monitoring/resources/pods#pod-logs).
 
-For a json schema example check [test log schema file](https://github.com/mia-platform/lc39/blob/master/tests/log.schema.json)
+For a JSON schema example check [test log schema file](https://github.com/mia-platform/lc39/blob/master/tests/log.schema.json)
 
 ## Additional information to response logs
 

--- a/docs/service-options.md
+++ b/docs/service-options.md
@@ -1,7 +1,7 @@
 # Service Options
 
 If you want to customize the Fastify instance over the default settings that **lc39** will set
-you can export a json object in your module:
+you can export a JSON object in your module:
 
 ```javascript
 module.exports.options = {
@@ -19,19 +19,31 @@ module.exports.options = {
     customLevels: {
       audit: 35,
       success: 70
+    },
+    hooks: {
+      logMethod (inputArgs, method, level) {
+        // Here you can manipulate the parameters passed to the logger methods
+        return method.apply(this, inputArgs) // This achieves the default behavior, i.e. not manipulating anything
+      }
     }
   }
 }
 ```
 
-The values supported in this object are the supported keys and value for the Fastify server instance
-that you can find at this [link][fastify-server-options]; with the exception of the `logger` parameter.  
+The key and values supported in this object correspond to the options of the Fastify server instance documented at [link][fastify-server-options],
+with the exception of the `logger` parameter, that allows you to:
+
+- add a [custom logging level][pino-custom-levels] using the `customLevel` field;
+- add [hooks][pino-hooks] to customize internal logger operations using the `hooks` field.
+
 Instead you can customize the `pino` instance via the `logLevel` and `logger.customLevels` keys, and you can modify the redaction rules
 via the `redact` key. For this key the accepted values are listed [here][pino-redact-options].  
 You have the following additional keys:
 - `oasRefResolver` that is passed to the `fastify-swagger` plugin as `refResolver`; its usage can be found [here][fastify-swagger-refs]. 
 
-[fastify-server-options]: https://github.com/fastify/fastify/blob/main/docs/Reference/Server.md
-[pino-redact-options]: https://github.com/pinojs/pino/blob/master/docs/redaction.md
 [fastify-sensible-error-handler]: https://github.com/fastify/fastify-sensible#custom-error-handler
+[fastify-server-options]: https://github.com/fastify/fastify/blob/main/docs/Reference/Server.md
 [fastify-swagger-refs]: https://github.com/fastify/fastify-swagger#managing-your-refs
+[pino-custom-levels]: https://github.com/pinojs/pino/blob/master/docs/api.md#opt-customlevels
+[pino-hooks]: https://github.com/pinojs/pino/blob/master/docs/api.md#hooks-object
+[pino-redact-options]: https://github.com/pinojs/pino/blob/master/docs/redaction.md

--- a/test-d/index.d-test.ts
+++ b/test-d/index.d-test.ts
@@ -35,6 +35,11 @@ const serverWithModuleAndAllOptions = lc39(plugin, {
   logger: {
     customLevels: {
       audit: 35,
+    },
+    hooks: {
+      logMethod (inputArgs, method, level) {
+        return method.apply(this, inputArgs)
+      }
     }
   },
   healthinessHandler: async (fastify) => {

--- a/tests/launch-fastify.test.js
+++ b/tests/launch-fastify.test.js
@@ -815,3 +815,16 @@ test('should use correctly the logger with custom levels', async assert => {
 
   assert.end()
 })
+
+test('should use correctly logger custom hooks', async assert => {
+  const fastifyInstance = await launch('./tests/modules/custom-hooks', {})
+  assert.teardown(() => fastifyInstance.close())
+
+  const response = await fastifyInstance.inject({
+    method: 'POST',
+    url: '/custom-hooks',
+  })
+
+  assert.strictSame(response.statusCode, 200)
+  assert.end()
+})

--- a/tests/modules/custom-hooks.js
+++ b/tests/modules/custom-hooks.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* istanbul ignore file */
+
+'use strict'
+
+module.exports = async function plugin(fastify) {
+  fastify.post('/custom-hooks', function handler(request, reply) {
+    this.log.info({
+      auditInfo: 'audit details',
+    }, 'Custom hooks> Log message with arguments')
+    this.log.info('Custom hooks> Log message without arguments')
+    reply.send({})
+  })
+}
+
+module.exports.options = {
+  logger: {
+    hooks: {
+      // eslint-disable-next-line no-unused-vars
+      logMethod(inputArgs, method, level) {
+        if (inputArgs.length >= 2) {
+          const arg1 = inputArgs.shift()
+          return method.apply(this, [{ auditEvent: arg1 }, ...inputArgs])
+        }
+        return method.apply(this, inputArgs)
+      },
+    },
+  },
+}


### PR DESCRIPTION
As discussed in the [linked issue](https://github.com/mia-platform/lc39/issues/363), I updated the documentation and tests to customize [Pino hooks](https://github.com/pinojs/pino/blob/master/docs/api.md#hooks-object) and intercept and manipulate logging arguments, which will be used for audit logs.

The current version of lc39 already allows to pass the custom hook in the `hooks` field of the Pino logger options, so no specific change was required.

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [X] tests are included
- [X] the documentation is updated or integrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
